### PR TITLE
Do not break iteration in case of multiple emmc devices

### DIFF
--- a/user-scripts/install-to-internal
+++ b/user-scripts/install-to-internal
@@ -41,7 +41,6 @@ if __name__ == "__main__":
         for line in lsblk_out:
             if line.find("mmcblk") != -1 or line.find("nvme") != -1:
                 storage_array.append(line[:7].strip())  # get actual device name
-                break
         if not storage_array:
             print_error("No internal storage found... Please create an issue")
             exit(1)


### PR DESCRIPTION
In case of multiple emmc devices, the iteration would stop at the first one, which could be the currently booted sdcard forcing the system to unmount root (description written by Apacelus)